### PR TITLE
Try to keep track of the correct locations whilst editing files

### DIFF
--- a/server/src/lsifServer.ts
+++ b/server/src/lsifServer.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 const exists = promisify(fs.exists);
 
 import URI from 'vscode-uri';
-import { createConnection, ProposedFeatures, InitializeParams, TextDocumentSyncKind, WorkspaceFolder, ServerCapabilities, TextDocument, TextDocumentPositionParams, TextDocumentIdentifier, BulkUnregistration, BulkRegistration, DocumentSymbolRequest, DocumentSelector, FoldingRangeRequest, HoverRequest, DefinitionRequest, ReferencesRequest } from 'vscode-languageserver';
+import { createConnection, ProposedFeatures, InitializeParams, TextDocumentSyncKind, WorkspaceFolder, TextDocumentIdentifier, BulkUnregistration, BulkRegistration, DocumentSymbolRequest, DocumentSelector, FoldingRangeRequest, HoverRequest, DefinitionRequest, ReferencesRequest } from 'vscode-languageserver';
 
 import { LsifDatabase } from './lsifDatabase';
 
@@ -26,7 +26,7 @@ connection.onInitialize((params: InitializeParams) => {
 	folders = params.workspaceFolders;
 	return {
 		capabilities: {
-			textDocumentSync: TextDocumentSyncKind.None,
+			textDocumentSync: TextDocumentSyncKind.Incremental,
 			workspace: {
 				workspaceFolders: {
 					supported: true,
@@ -198,9 +198,19 @@ connection.onDefinition((params) => {
 connection.onReferences((params) => {
 	let [uri, database] = getDatabase(params.textDocument);
 	if (!database) {
+
 		return null;
 	}
 	return database.references(uri, params.position, params.context);
 });
+
+
+connection.onDidChangeTextDocument((params) => {
+	let [uri, database] = getDatabase(params.textDocument);
+	if (!database) {
+		return null;
+	}
+	return database.updateLocations(uri, params.contentChanges);
+})
 
 connection.listen();


### PR DESCRIPTION
The language server is a bit useless as soon as you start editing files as all the locations are immediately incorrect. This means all the hovers are in the wrong place and so on.

This patch tries to work out the correct mapping from the old to new locations so that you can edit a file and the ranges are resolved correctly.

The logic is based on a Haskell implementation of the same idea by Luke Lau (@Bubba) and Zubin Duggal (@wz1000)