### PR TITLE
Fix filesystem lookup for top level files

### DIFF
--- a/server/src/files.ts
+++ b/server/src/files.ts
@@ -118,7 +118,7 @@ export class FileSystem {
 		let parts = uri.split('/');
 		let entry: Entry = this.root;
 		for (const part of parts) {
-			if (!part) {
+			if (!part || part === '.') {
 				continue;
 			}
 			let child: Entry | undefined;


### PR DESCRIPTION
Previous to this change, if you loaded up an LSIF file with top-level files, the extension would enter an infinite loop looking for `.` over and over.